### PR TITLE
Update cookbook get/download function to work with latest supermarket versions

### DIFF
--- a/lib/knife-mirror/version.rb
+++ b/lib/knife-mirror/version.rb
@@ -1,5 +1,5 @@
 # KnifeMirror version
 module KnifeMirror
-  VERSION = '0.1.2'
+  VERSION = '0.2.0'
   MAJOR, MINOR, TINY = VERSION.split('.')
 end


### PR DESCRIPTION
- fix for cookbook versions with end-line character '\n'
- fix for deprecated cookbooks without `replacement` attribute
- update unauthenticated_get_rest function to work with supermarket `>= 3.1.22`

https://github.com/chef/chef/blob/29765adb7174256880d574c36435a78ce8272d5d/lib/chef/knife/supermarket_download.rb#L101
https://github.com/chef/chef/blob/29765adb7174256880d574c36435a78ce8272d5d/lib/chef/knife/supermarket_download.rb#L79